### PR TITLE
enhancement: implement getContext method for device emulation

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1,6 +1,6 @@
 import { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { ChatOpenAI } from "@langchain/openai";
-import { Browser, BrowserContext, devices, Page } from "playwright";
+import { Browser, BrowserContext, Page } from "playwright";
 import { v4 as uuidv4 } from "uuid";
 
 import {
@@ -76,7 +76,6 @@ export class HyperAgent<T extends BrowserProviders = "Local"> {
     } else {
       this.llm = params.llm;
     }
-    this.useMobile = params?.useMobile ?? false;
     this.browserProviderType = (params.browserProvider ?? "Local") as T;
 
     this.browserProvider = (
@@ -101,22 +100,10 @@ export class HyperAgent<T extends BrowserProviders = "Local"> {
    */
   public async initBrowser(): Promise<Browser> {
     if (!this.browser) {
-      const iphone12 = devices["iPhone 12"];
-
       this.browser = await this.browserProvider.start();
-      this.context = await this.browser.newContext(
-        this.useMobile
-          ? {
-              userAgent: iphone12.userAgent,
-              viewport: {
-                width: iphone12.viewport.width,
-                height: iphone12.viewport.height + 100,
-              },
-            }
-          : {
-              viewport: null,
-            }
-      );
+      this.context = await this.browser.newContext({
+        viewport: null,
+      });
 
       // Inject script to track event listeners
       await this.context.addInitScript(() => {

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1,6 +1,6 @@
 import { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { ChatOpenAI } from "@langchain/openai";
-import { Browser, BrowserContext, Page } from "playwright";
+import { Browser, BrowserContext, devices, Page } from "playwright";
 import { v4 as uuidv4 } from "uuid";
 
 import {
@@ -40,6 +40,7 @@ export class HyperAgent<T extends BrowserProviders = "Local"> {
   private tokenLimit = 128000;
   private debug = false;
   private mcpClient: MCPClient | undefined;
+  private useMobile: boolean = false;
   private browserProvider: T extends "Hyperbrowser"
     ? HyperbrowserProvider
     : LocalBrowserProvider;
@@ -75,6 +76,7 @@ export class HyperAgent<T extends BrowserProviders = "Local"> {
     } else {
       this.llm = params.llm;
     }
+    this.useMobile = params?.useMobile ?? false;
     this.browserProviderType = (params.browserProvider ?? "Local") as T;
 
     this.browserProvider = (
@@ -99,10 +101,22 @@ export class HyperAgent<T extends BrowserProviders = "Local"> {
    */
   public async initBrowser(): Promise<Browser> {
     if (!this.browser) {
+      const iphone12 = devices["iPhone 12"];
+
       this.browser = await this.browserProvider.start();
-      this.context = await this.browser.newContext({
-        viewport: null,
-      });
+      this.context = await this.browser.newContext(
+        this.useMobile
+          ? {
+              userAgent: iphone12.userAgent,
+              viewport: {
+                width: iphone12.viewport.width,
+                height: iphone12.viewport.height + 100,
+              },
+            }
+          : {
+              viewport: null,
+            }
+      );
 
       // Inject script to track event listeners
       await this.context.addInitScript(() => {

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -45,6 +45,7 @@ export class HyperAgent<T extends BrowserProviders = "Local"> {
     : LocalBrowserProvider;
   private browserProviderType: T;
   private actions: Array<AgentActionDefinition> = [...DEFAULT_ACTIONS];
+  private clientType: "desktop" | "mobile";
 
   public browser: Browser | null = null;
   public context: BrowserContext | null = null;
@@ -76,6 +77,7 @@ export class HyperAgent<T extends BrowserProviders = "Local"> {
       this.llm = params.llm;
     }
     this.browserProviderType = (params.browserProvider ?? "Local") as T;
+    this.clientType = params.clientType ?? "desktop";
 
     this.browserProvider = (
       this.browserProviderType === "Hyperbrowser"
@@ -100,9 +102,13 @@ export class HyperAgent<T extends BrowserProviders = "Local"> {
   public async initBrowser(): Promise<Browser> {
     if (!this.browser) {
       this.browser = await this.browserProvider.start();
-      this.context = await this.browser.newContext({
-        viewport: null,
-      });
+      this.context = await this.browserProvider.getContext(this.clientType);
+
+      if (!this.context) {
+        this.context = await this.browser.newContext({
+          viewport: null,
+        });
+      }
 
       // Inject script to track event listeners
       await this.context.addInitScript(() => {

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -40,7 +40,6 @@ export class HyperAgent<T extends BrowserProviders = "Local"> {
   private tokenLimit = 128000;
   private debug = false;
   private mcpClient: MCPClient | undefined;
-  private useMobile: boolean = false;
   private browserProvider: T extends "Hyperbrowser"
     ? HyperbrowserProvider
     : LocalBrowserProvider;

--- a/src/browser-providers/hyperbrowser.ts
+++ b/src/browser-providers/hyperbrowser.ts
@@ -1,4 +1,10 @@
-import { chromium, Browser, ConnectOverCDPOptions } from "playwright";
+import {
+  chromium,
+  Browser,
+  ConnectOverCDPOptions,
+  BrowserContext,
+  devices,
+} from "playwright";
 import { Hyperbrowser } from "@hyperbrowser/sdk";
 import {
   CreateSessionParams,
@@ -60,6 +66,21 @@ export class HyperbrowserProvider extends BrowserProvider<SessionDetail> {
     if (this.session) {
       await this.hbClient?.sessions.stop(this.session.id);
     }
+  }
+
+  public async getContext(
+    device: string = "desktop"
+  ): Promise<BrowserContext | null> {
+    if (!this.browser) return null;
+
+    if (device === "mobile") {
+      const iPhone = devices["iPhone 12"];
+      return await this.browser.newContext({
+        ...iPhone,
+      });
+    }
+
+    return await this.browser.newContext();
   }
 
   public getSession() {

--- a/src/browser-providers/hyperbrowser.ts
+++ b/src/browser-providers/hyperbrowser.ts
@@ -76,7 +76,11 @@ export class HyperbrowserProvider extends BrowserProvider<SessionDetail> {
     if (device === "mobile") {
       const iPhone = devices["iPhone 12"];
       return await this.browser.newContext({
-        ...iPhone,
+        userAgent: iPhone.userAgent,
+        viewport: {
+          width: iPhone.viewport.width + 50,
+          height: iPhone.viewport.height + 50,
+        },
       });
     }
 

--- a/src/browser-providers/local.ts
+++ b/src/browser-providers/local.ts
@@ -47,7 +47,11 @@ export class LocalBrowserProvider extends BrowserProvider<Browser> {
     if (device === "mobile") {
       const iPhone = devices["iPhone 12"];
       return await this.session.newContext({
-        ...iPhone,
+        userAgent: iPhone.userAgent,
+        viewport: {
+          width: iPhone.viewport.width + 50,
+          height: iPhone.viewport.height + 50,
+        },
       });
     }
 

--- a/src/browser-providers/local.ts
+++ b/src/browser-providers/local.ts
@@ -1,17 +1,17 @@
-import { chromium, Browser, LaunchOptions, devices } from "playwright";
+import {
+  chromium,
+  Browser,
+  LaunchOptions,
+  devices,
+  BrowserContext,
+} from "playwright";
 import BrowserProvider from "@/types/browser-providers/types";
 
-type LocalBrowserProviderOptions =
-  | (Omit<Omit<LaunchOptions, "headless">, "channel"> & {
-      device?: keyof typeof devices;
-    })
-  | undefined;
-
 export class LocalBrowserProvider extends BrowserProvider<Browser> {
-  options: LocalBrowserProviderOptions;
+  options: Omit<Omit<LaunchOptions, "headless">, "channel"> | undefined;
   session: Browser | undefined;
 
-  constructor(options?: LocalBrowserProviderOptions) {
+  constructor(options?: Omit<Omit<LaunchOptions, "headless">, "channel">) {
     super();
     this.options = options;
   }
@@ -24,30 +24,33 @@ export class LocalBrowserProvider extends BrowserProvider<Browser> {
       headless: false,
       args: ["--disable-blink-features=AutomationControlled", ...launchArgs],
     });
-
     this.session = browser;
-    if (this?.options?.device) {
-      const defaultContexts = browser.contexts();
-      for (const context of defaultContexts) {
-        await context.close();
-      }
-
-      const newContext = await browser.newContext({
-        ...devices[this.options.device],
-      });
-
-      await newContext.newPage();
-    }
-
     return this.session;
   }
+
   async close(): Promise<void> {
     return await this.session?.close();
   }
+
   public getSession() {
     if (!this.session) {
       return null;
     }
     return this.session;
+  }
+
+  public async getContext(
+    device: string = "desktop"
+  ): Promise<BrowserContext | null> {
+    if (!this.session) return null;
+
+    if (device === "mobile") {
+      const iPhone = devices["iPhone 12"];
+      return await this.session.newContext({
+        ...iPhone,
+      });
+    }
+
+    return await this.session.newContext();
   }
 }

--- a/src/types/browser-providers/types.ts
+++ b/src/types/browser-providers/types.ts
@@ -1,10 +1,11 @@
-import { Browser } from "playwright";
+import { Browser, BrowserContext } from "playwright";
 
 abstract class BrowserProvider<T> {
   abstract session: unknown;
   abstract start(): Promise<Browser>;
   abstract close(): Promise<void>;
-  abstract getSession(): T|null;
+  abstract getSession(): T | null;
+  abstract getContext(device?: string): Promise<BrowserContext | null>;
 }
 
 export default BrowserProvider;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -63,7 +63,7 @@ export interface HyperAgentConfig<T extends BrowserProviders = "Local"> {
 
   debug?: boolean;
   llm?: BaseChatModel;
-
+  clientType?: "mobile" | "desktop";
   hyperbrowserConfig?: Omit<
     NonNullable<ConstructorParameters<typeof HyperbrowserProvider>[0]>,
     "debug"

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -68,5 +68,6 @@ export interface HyperAgentConfig<T extends BrowserProviders = "Local"> {
     NonNullable<ConstructorParameters<typeof HyperbrowserProvider>[0]>,
     "debug"
   >;
+  useMobile?: boolean;
   localConfig?: ConstructorParameters<typeof LocalBrowserProvider>[0];
 }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -68,6 +68,5 @@ export interface HyperAgentConfig<T extends BrowserProviders = "Local"> {
     NonNullable<ConstructorParameters<typeof HyperbrowserProvider>[0]>,
     "debug"
   >;
-  useMobile?: boolean;
   localConfig?: ConstructorParameters<typeof LocalBrowserProvider>[0];
 }


### PR DESCRIPTION
### LocalBrowserProvider Configuration

This PR explains and have added the use-case on how to use the `clientType` setting when configuring a `HyperAgent` instance with the `LocalBrowserProvider`.

## Usage

Use the `clientType` parameter to control whether the browser context should emulate a desktop or a mobile device.

```ts
const agent = new HyperAgent({
  llm: llm,
  browserProvider: "Local",
  clientType: "desktop", // Options: 'desktop' or 'mobile'
  debug: true,
});
```

### Notes
- Default value: "desktop"
- This solution will work on both `LocalProvider` and `HyperBrowserProvide`.
