### PR TITLE
Fix interactive elements variable name

### DIFF
--- a/src/context-providers/dom/find-interactive-elements.ts
+++ b/src/context-providers/dom/find-interactive-elements.ts
@@ -2,7 +2,7 @@ import { isIgnoredElem, isInteractiveElem } from "./elem-interactive";
 import { InteractiveElement } from "./types";
 
 export const findInteractiveElements = (): InteractiveElement[] => {
-  const intereactiveElements: InteractiveElement[] = [];
+  const interactiveElements: InteractiveElement[] = [];
   const processedElements = new Set<HTMLElement>();
 
   const processRoot = (
@@ -29,7 +29,7 @@ export const findInteractiveElements = (): InteractiveElement[] => {
       if (isIgnoredElem(element) || !isInteractive) {
         continue;
       }
-      intereactiveElements.push({
+      interactiveElements.push({
         element,
         iframe: rootInfo.iframe,
         shadowHost: rootInfo.shadowHost,
@@ -59,5 +59,5 @@ export const findInteractiveElements = (): InteractiveElement[] => {
     }
   }
 
-  return intereactiveElements;
+  return interactiveElements;
 };

--- a/src/context-providers/dom/inject/build-dom-view-script.js
+++ b/src/context-providers/dom/inject/build-dom-view-script.js
@@ -110,7 +110,7 @@
 
   // src/context-providers/dom/find-interactive-elements.ts
   var findInteractiveElements = () => {
-    const intereactiveElements = [];
+    const interactiveElements = [];
     const processedElements = /* @__PURE__ */ new Set();
     const processRoot = (root, rootInfo = {}) => {
       const elements = root.querySelectorAll("*");
@@ -130,7 +130,7 @@
         if (isIgnoredElem(element) || !isInteractive) {
           continue;
         }
-        intereactiveElements.push({
+        interactiveElements.push({
           element,
           iframe: rootInfo.iframe,
           shadowHost: rootInfo.shadowHost,
@@ -155,7 +155,7 @@
         console.warn("error processing iframe", e);
       }
     }
-    return intereactiveElements;
+    return interactiveElements;
   };
 
   // src/context-providers/dom/highlight.ts

--- a/src/context-providers/dom/inject/build-dom-view.ts
+++ b/src/context-providers/dom/inject/build-dom-view.ts
@@ -110,7 +110,7 @@ export const buildDomViewJs = `(() => {
 
   // src/context-providers/dom/find-interactive-elements.ts
   var findInteractiveElements = () => {
-    const intereactiveElements = [];
+    const interactiveElements = [];
     const processedElements = /* @__PURE__ */ new Set();
     const processRoot = (root, rootInfo = {}) => {
       const elements = root.querySelectorAll("*");
@@ -130,7 +130,7 @@ export const buildDomViewJs = `(() => {
         if (isIgnoredElem(element) || !isInteractive) {
           continue;
         }
-        intereactiveElements.push({
+        interactiveElements.push({
           element,
           iframe: rootInfo.iframe,
           shadowHost: rootInfo.shadowHost,
@@ -155,7 +155,7 @@ export const buildDomViewJs = `(() => {
         console.warn("error processing iframe", e);
       }
     }
-    return intereactiveElements;
+    return interactiveElements;
   };
 
   // src/context-providers/dom/highlight.ts


### PR DESCRIPTION
## Summary
- rename `intereactiveElements` typo to `interactiveElements`
- update generated DOM view scripts with the corrected variable name

## Testing
- `yarn test` *(fails: package not in lockfile)*