### PR TITLE
runAgentTask: fix a logic bug

### DIFF
--- a/src/agent/tools/agent.ts
+++ b/src/agent/tools/agent.ts
@@ -104,13 +104,14 @@ export const runAgentTask = async (
   taskState: TaskState,
   params?: TaskParams
 ): Promise<TaskOutput> => {
+  if (!taskState) {
+    throw new HyperagentError(`Task not found`);
+  }
   const taskId = taskState.id;
+
   const debugDir = params?.debugDir || `debug/${taskId}`;
   if (ctx.debug) {
     console.log(`Debugging task ${taskId} in ${debugDir}`);
-  }
-  if (!taskState) {
-    throw new HyperagentError(`Task ${taskId} not found`);
   }
 
   taskState.status = TaskStatus.RUNNING as TaskStatus;


### PR DESCRIPTION
Correct the bug: if `taskState` does not exist, it won't be ablle to return taskState.id