### PR TITLE
Fix dom state retrieval

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperbrowser/agent",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Hyperbrowsers Web Agent",
   "author": "",
   "main": "dist/index.js",

--- a/src/agent/tools/agent.ts
+++ b/src/agent/tools/agent.ts
@@ -149,12 +149,13 @@ export const runAgentTask = async (
     }
 
     // Get DOM State
-    const domState = await retry({ func: () => getDom(page) });
-    if (!domState) {
-      console.log("no dom state, waiting 1 second.");
-      await sleep(1000);
-      continue;
-    }
+    const domState = await retry({
+      func: async () => {
+        const s = await getDom(page);
+        if (!s) throw new Error("no dom state");
+        return s;
+      },
+    });
 
     const trimmedScreenshot = await compositeScreenshot(
       page,

--- a/src/agent/tools/agent.ts
+++ b/src/agent/tools/agent.ts
@@ -155,6 +155,9 @@ export const runAgentTask = async (
         if (!s) throw new Error("no dom state");
         return s;
       },
+      params: {
+        retryCount: 3,
+      },
     });
 
     const trimmedScreenshot = await compositeScreenshot(

--- a/src/agent/tools/agent.ts
+++ b/src/agent/tools/agent.ts
@@ -164,7 +164,7 @@ export const runAgentTask = async (
     } catch (error) {
       if (ctx.debug) {
         console.log(
-          "Failed to retrieve DOM state after 3 retries. Cancelling task.",
+          "Failed to retrieve DOM state after 3 retries. Failing task.",
           error
         );
       }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds 3-attempt DOM state retrieval with failure handling in agent loop; bumps version to 0.10.0.
> 
> - **Agent**:
>   - **DOM state retrieval** in `src/agent/tools/agent.ts`:
>     - Add explicit 3-attempt retry and null-checks when calling `getDom`.
>     - On repeated failure, set `taskState.status` to `FAILED`, record error, break loop, and log in debug mode.
> - **Version**:
>   - Bump `package.json` version to `0.10.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa2994665763ab504d7a1bb6eb1c2b1db58aaa2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->