### PR TITLE
fix: add missing config to Gemini client invoke method

### DIFF
--- a/src/llm/providers/gemini.ts
+++ b/src/llm/providers/gemini.ts
@@ -53,6 +53,10 @@ export class GeminiClient implements HyperAgentLLM {
     const response = await this.client.models.generateContent({
       model: this.model,
       contents: geminiMessages as any,
+      config: {
+        temperature: options?.temperature ?? this.temperature,
+        maxOutputTokens: options?.maxTokens ?? this.maxTokens,
+      },
     });
 
     const text = response.text;


### PR DESCRIPTION
## Summary
- Fixed bug where `GeminiClient.invoke()` was not passing `temperature` and `maxOutputTokens` to the API
- The `invokeStructured()` method correctly included these parameters, but `invoke()` did not
- This caused users' temperature settings to be silently ignored for regular (non-structured) Gemini calls

## Changes
Added the missing `config` block to match `invokeStructured()`:
```typescript
config: {
  temperature: options?.temperature ?? this.temperature,
  maxOutputTokens: options?.maxTokens ?? this.maxTokens,
},
```

## Test plan
- [ ] Verify TypeScript compiles without errors
- [ ] Test Gemini provider with explicit temperature setting to confirm it's respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> `GeminiClient.invoke` now forwards `temperature` and `maxTokens` (as `config.maxOutputTokens`) to the Gemini API.
> 
> - **Gemini provider (`src/llm/providers/gemini.ts`)**:
>   - Add `config` to `invoke` request, forwarding `temperature` and `maxOutputTokens` to the API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3fba9b40faab97e51e1f3886383342b097cea80. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->