### PR TITLE
fix/cli rawmode guard

### DIFF
--- a/src/llm/providers/gemini.ts
+++ b/src/llm/providers/gemini.ts
@@ -53,6 +53,10 @@ export class GeminiClient implements HyperAgentLLM {
     const response = await this.client.models.generateContent({
       model: this.model,
       contents: geminiMessages as any,
+      config: {
+        temperature: options?.temperature ?? this.temperature,
+        maxOutputTokens: options?.maxTokens ?? this.maxTokens,
+      },
     });
 
     const text = response.text;


### PR DESCRIPTION
- **fix: add missing config to Gemini client invoke method**
- **Guard CLI raw mode in non-TTY environments**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Guard CLI keypress/raw-mode behind TTY checks and send temperature/maxTokens to Gemini generateContent.
> 
> - **CLI (`src/cli/index.ts`)**:
>   - Guard keypress handling and `process.stdin.setRawMode(true)` behind `process.stdin.isTTY`.
>   - Apply TTY guard when resuming stdin in `onStep`, `debugAgentOutput`, and after follow-up prompt in `onComplete`.
> - **LLM Provider (`src/llm/providers/gemini.ts`)**:
>   - Add `config` to `generateContent` with `temperature` and `maxOutputTokens` sourced from options/defaults.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9435909a8fb5a4572bb13e8688c21b57728c0d72. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->